### PR TITLE
added support for default and per endpoint headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# Jetbrains IDE settings folder
+.idea

--- a/README.md
+++ b/README.md
@@ -208,6 +208,61 @@ toTimeString | `09:30:16 GMT-0400 (EDT)'`
 toUTCString | `Fri, 15 May 2015 13:30:16 GMT`
 toYMDString | `2015-05-15`
 
+## Headers
+
+Sometimes you need to mock an API, and also need to mock some headers e.g add CORS support.
+
+### Default Headers
+
+In this case, declare your config as an object instead of an array.
+
+These headers will be added to every response
+
+```javascript
+// api.js
+var API = require('api-stub');
+var config = {
+  defaultHeaders: [
+    {
+      name: 'Access-Control-Allow-Origin',
+      value: '*'
+    }
+  ],
+  endpoints: [
+    {
+      path:'/status',
+      data: {status: true}
+    }
+  ]
+}
+var server = new API(config);
+server.start(3000);
+//then run the script `node api.js`
+
+```
+
+### Endpoint Specific Headers
+
+You can also add headers to an individual endpoint. These will be applied after any default headers (if applicable)
+
+```javascript
+// api.js
+var API = require('api-stub');
+var config = [{
+  path:'/status',
+  data: {status: true},
+  headers: [
+    {
+      name: 'My-Header-Name',
+      value: 'my header value'
+    }
+  ]
+}]
+var server = new API(config);
+server.start(3000);
+//then run the script `node api.js`
+
+```
 
 ## FAQ
 ### Yet another API mock up tool huh?

--- a/src/apidata.js
+++ b/src/apidata.js
@@ -258,6 +258,7 @@ Return: Object with access to methods
 */
 function APIData(endpointSettings){
   var apidata = cloneAndInvoke(endpointSettings.data);
+  var headers = endpointSettings.headers;
   var instructions = parseData(apidata)
   var templates = prepareTemplates(endpointSettings.templates);
 
@@ -268,7 +269,8 @@ function APIData(endpointSettings){
   }
 
   return {
-    getJSONString: getJSONString
+    getJSONString: getJSONString,
+    headers: headers
   };
 }
 


### PR DESCRIPTION
This is a very nice little library for quickly stubbing endpoints, however I was running into CORS issues, so I needed header support.

This PR allows you to pass in the config as an array, or as an object, which contains the default headers, and the endpoints.

I have also added support for headers per endpoint.
